### PR TITLE
Enable CD

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - jglick
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,1 @@
 _extends: .github
-tag-template: build-token-root-$NEXT_MINOR_VERSION

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,57 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
+    steps:
+      - name: Verify CI status
+        uses: jenkins-infra/verify-ci-status-action@v1.2.0
+        id: verify-ci-status
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output_result: true
+
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check interesting categories
+        uses: jenkins-infra/interesting-category-action@v1.0.0
+        id: interesting-categories
+        if: steps.verify-ci-status.outputs.result == 'success'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: needs.validate.outputs.should_release == 'true'
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2.3.4
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 8
+    - name: Release
+      uses: jglick/jenkins-maven-cd-action@59e4b84127bc0c89bb5231212a2a3bf9ec408b8f # TODO https://github.com/jenkins-infra/jenkins-maven-cd-action/pull/14
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
Like https://github.com/jenkinsci/plugin-pom/pull/462, another way to test https://github.com/jenkins-infra/jenkins-maven-cd-action/pull/14 though in this case I may later just switch it to full JEP-229. Requires https://github.com/jenkins-infra/repository-permissions-updater/pull/2225.
