### PR TITLE
Align status when queuing jobs quickly with core behavior (303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ interleaving `job/` string).
 (The variant sub-URIs `buildWithParameters` and `polling` are also
 supported, as is the usual `delay` query parameter.)
 
+The server replies with a “201 Created” status code when a build is
+queued successfully. When a build is already scheduled, the server
+replies with a “303 See Other”, the `Location` header pointing to the
+scheduled build URL. Clients without the `READ` permission on the build
+should not follow the redirect, as it will lead to a page they do not
+have permission to see.
+
 To create a token for your job, go to the job configuration, select
 **Trigger Builds Remotely** in the build triggers section. The token
 you set here is what you will pass via the url.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The plugin behavior to consecutive build requests was:

1. 201 Created. (Build queued)
2. 201 Created. (First build is in progress, build queued)
3. 302 Found. Location: ., which ends up being the `/buildByToken/`
   path. Following the redirect, clients receive a 404 as the page does
   not exist.

Instead, redirect clients to the queued build, following core Jenkins
behavior.
https://github.com/jenkinsci/jenkins/blob/e27b310065b3c036b5fc9d123f1d1d99d3058c00/core/src/main/java/hudson/model/ParametersDefinitionProperty.java#L199

Use the `schedule2` operation for finer-grained results on the
scheduling results. Replaces the deprecated `schedule`.